### PR TITLE
ParseType Argument Exception fix in XdcToMarkdown tool

### DIFF
--- a/Tools/XmlDocGen/XdcParser.cs
+++ b/Tools/XmlDocGen/XdcParser.cs
@@ -21,8 +21,6 @@ public class XdcParser
             var memberName = member.Attributes.GetNamedItem("name").InnerText;
             try
             {
-
-
                 switch (memberName[0])
                 {
                     case 'M': ParseMethod(members, member, memberName); break;

--- a/Tools/XmlDocGen/XdcParser.cs
+++ b/Tools/XmlDocGen/XdcParser.cs
@@ -19,14 +19,22 @@ public class XdcParser
         foreach (XmlNode member in xmlMembers.SelectNodes("member"))
         {
             var memberName = member.Attributes.GetNamedItem("name").InnerText;
-
-            switch (memberName[0])
+            try
             {
-                case 'M':   ParseMethod(members, member, memberName);                   break;
-                case 'P':   ParseProperty(members, member, memberName);                 break;
-                case 'T':   ParseType(members, member, memberName);                     break;
-                case 'F':   ParseField(members, member, memberName);                    break;
-                default:    Console.WriteLine($"Invalid type of member: {memberName}"); break;
+
+
+                switch (memberName[0])
+                {
+                    case 'M': ParseMethod(members, member, memberName); break;
+                    case 'P': ParseProperty(members, member, memberName); break;
+                    case 'T': ParseType(members, member, memberName); break;
+                    case 'F': ParseField(members, member, memberName); break;
+                    default: Console.WriteLine($"Invalid type of member: {memberName}"); break;
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"An error has occured during processing the record {memberName}. Details: {ex}");
             }
         }
 
@@ -88,7 +96,7 @@ public class XdcParser
     {
         members.Add(new Models.Property(
             memberName[2..],
-            member == null ? string.Empty : member.SelectSingleNode("summary").InnerText
+            member == null ? string.Empty : member.SelectSingleNode("summary")?.InnerText ?? String.Empty
         ));
     }
 


### PR DESCRIPTION
Added:
- [x] Additional checks in property parser and general parser.